### PR TITLE
Explicitly give a status

### DIFF
--- a/captcha.go
+++ b/captcha.go
@@ -243,6 +243,7 @@ func Captchaer(options ...Options) macaron.Handler {
 			if _, err := NewImage([]byte(chars), cpt.StdWidth, cpt.StdHeight, cpt.ColorPalette).WriteTo(ctx.Resp); err != nil {
 				panic(fmt.Errorf("write captcha: %v", err))
 			}
+			ctx.Status(200)
 			return
 		}
 


### PR DESCRIPTION
 After serving image successfully, give an explicit status, this will fix random fail of captcha.